### PR TITLE
Atlantis latest, tf 0.12.3, tg 0.19.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM runatlantis/atlantis:v0.8.2
+FROM runatlantis/atlantis:latest
 LABEL authors="Rui Chen <chenrui333@gmail.com>"
 
-ENV TERRAGRUNT_VERSION=v0.19.5
+ENV TERRAGRUNT_VERSION=v0.19.6
 
 RUN curl -s -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
     chmod +x terragrunt && \


### PR DESCRIPTION
Switch back to use `runatlantis/atlantis:latest` docker tag:
![image](https://user-images.githubusercontent.com/1580956/60326660-a86b0c80-99bc-11e9-849c-65d564d8c1cd.png)

Relates to PR, https://github.com/runatlantis/atlantis/pull/685
